### PR TITLE
Correct internal links between builds

### DIFF
--- a/build/1.7/zerthox/hexotic-pve.html
+++ b/build/1.7/zerthox/hexotic-pve.html
@@ -16,7 +16,7 @@ build:
         - "If you feel like you are too squishy, switch the Skill Haste on the Holster for Health. If you want even more Toughness, get Health instead of Skill Haste on the Gear Mods aswell."
         - "It can be used with literally any weapon in the game, I suggest running with an assault rifle due to the Enemy Armor Damage and an bolt-action sniper for one hit headshots though."
         - "If you feel like you need it you can run with Stability or Accuracy instead of Critical Hit Damage on the weapon mods."
-        - "If you want to have a similiar build without Adept stacking for PvP, I suggest checking out my <a href='/build/zerthox/hexotic-pvp'>Hexotic PvP DPS</a> build."
+        - "If you want to have a similiar build without Adept stacking for PvP, I suggest checking out my <a href='/build/1.7/zerthox/hexotic-pvp'>Hexotic PvP DPS</a> build."
     weapons: 
         primary: 
             name: "Lightweight M4"

--- a/build/1.7/zerthox/hexotic-pvp-adept.html
+++ b/build/1.7/zerthox/hexotic-pvp-adept.html
@@ -15,9 +15,9 @@ build:
         - "This is a DPS build for PvP. It is designed to be useful for solo and group play."
         - "It can be used with literally any weapon in the game, I suggest running with at least one Assault Rifle or SMG in PvP though."
         - "This build uses Adept stacking. Currently the Adept talent can be stacked up to 5 times with enough Skill Haste which grants you a total of 37.5 Critical Hit Chance."
-        - "If you do not want to use Adept stacking, check out the normal version of this build: <a href='/build/zerthox/hexotic-pvp'>Hexotic PvP DPS</a>."
+        - "If you do not want to use Adept stacking, check out the normal version of this build: <a href='/build/1.7/zerthox/hexotic-pvp'>Hexotic PvP DPS</a>."
         - "Rolling Stability or Accuracy on the weapon mods does not really matter, feel free pick your preferred handling stat. But the Optimal Range on the underbarrel is for SMGs more beneficial that Stability or Accuracy in my opinion."
-        - "If you want to have a similiar build for PvE, I suggest checking out my <a href='/build/id/zerthox/hexotic-pve'>Hexotic PvE DPS</a> build."
+        - "If you want to have a similiar build for PvE, I suggest checking out my <a href='/build/1.7/zerthox/hexotic-pve'>Hexotic PvE DPS</a> build."
     weapons: 
         primary: 
             name: "Lightweight M4"

--- a/build/1.7/zerthox/hexotic-pvp.html
+++ b/build/1.7/zerthox/hexotic-pvp.html
@@ -15,9 +15,9 @@ build:
         - "This is a DPS build for PvP. It is designed to be useful for solo and group play."
         - "It can be used with literally any weapon in the game, I suggest running with at least one Assault Rifle or SMG in PvP though."
         - "If you feel like you are too squishy, switch the Skill Haste on the Holster for Health. If you want even more Toughness, get Health instead of Skill Haste on the Gear Mods aswell."
-        - "This build can be used with Adept stacking: <a href='/build/id/zerthox/hexotic-pvp-adept'>Hexotic PvP Adept Stacking</a>."
+        - "This build can be used with Adept stacking: <a href='/build/1.7/zerthox/hexotic-pvp-adept'>Hexotic PvP Adept Stacking</a>."
         - "Rolling Stability or Accuracy on the weapon mods does not really matter, feel free pick your preferred handling stat. But the Optimal Range on the underbarrel is for SMGs more beneficial that Stability or Accuracy in my opinion."
-        - "If you want to have a similiar build for PvE, I suggest checking out my <a href='/build/zerthox/hexotic-pve'>Hexotic PvE DPS</a> build."
+        - "If you want to have a similiar build for PvE, I suggest checking out my <a href='/build/1.7/zerthox/hexotic-pve'>Hexotic PvE DPS</a> build."
     weapons: 
         primary: 
             name: "Lightweight M4"


### PR DESCRIPTION
Some of the links were not including the patch version number segment of
the URL and, as such, were breaking (404).

This PR inserts the segment where required in order for the links to be
functional.